### PR TITLE
Add support for WeMOS d1 mini Pro device.

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniProDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniProDeviceProvider.kt
@@ -30,7 +30,7 @@ class WemosD1MiniProDeviceProvider : MicroPythonDeviceProvider {
     get() = MicroPythonUsbId(0x10C4, 0xEA60)
 
   override val documentationURL: String
-    get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/WEMOS-D1-mini"
+    get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/WEMOS-D1-mini-Pro"
 
   override val packageRequirements: List<PyRequirement> by lazy {
     PyRequirement.fromText("""pyserial>=3.3,<3.4""")

--- a/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniProDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniProDeviceProvider.kt
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jetbrains.micropython.devices
 
 import com.jetbrains.micropython.settings.MicroPythonUsbId
 import com.jetbrains.python.packaging.PyRequirement
 
 /**
- * @author vlan
+ * @author lensvol
  */
 class WemosD1MiniProDeviceProvider : MicroPythonDeviceProvider {
   override val persistentName: String

--- a/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniProDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniProDeviceProvider.kt
@@ -1,0 +1,22 @@
+package com.jetbrains.micropython.devices
+
+import com.jetbrains.micropython.settings.MicroPythonUsbId
+import com.jetbrains.python.packaging.PyRequirement
+
+/**
+ * @author vlan
+ */
+class WemosD1MiniProDeviceProvider : MicroPythonDeviceProvider {
+  override val persistentName: String
+    get() = "WEMOS D1 mini Pro"
+
+  override val usbId: MicroPythonUsbId?
+    get() = MicroPythonUsbId(0x10C4, 0xEA60)
+
+  override val documentationURL: String
+    get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/WEMOS-D1-mini"
+
+  override val packageRequirements: List<PyRequirement> by lazy {
+    PyRequirement.fromText("""pyserial>=3.3,<3.4""")
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -51,6 +51,7 @@
   <extensions defaultExtensionNs="com.jetbrains.micropython">
     <deviceProvider implementation="com.jetbrains.micropython.devices.MicroBitDeviceProvider"/>
     <deviceProvider implementation="com.jetbrains.micropython.devices.WemosD1MiniDeviceProvider"/>
+    <deviceProvider implementation="com.jetbrains.micropython.devices.WemosD1MiniProDeviceProvider"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
Pro version of "d1 mini" board has a different USB-to-UART controller (CP2102/CP2109 UART Bridge Controller) and larger flash size, so it seems prudent to add it as a separate supported board.

Although I am not averse to merging those PIDs/VIDs into existing WeMOS provider. :)
