### PR TITLE
Initial batch of typehints for ESP8266 devices (machine, esp, time).

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniDeviceProvider.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.micropython.devices
 
+import com.jetbrains.micropython.settings.MicroPythonTypeHints
 import com.jetbrains.micropython.settings.MicroPythonUsbId
 import com.jetbrains.python.packaging.PyRequirement
 
@@ -15,6 +16,10 @@ class WemosD1MiniDeviceProvider : MicroPythonDeviceProvider {
 
   override val usbId: MicroPythonUsbId?
     get() = MicroPythonUsbId(0x1A86, 0x7523)
+
+  override val typeHints: MicroPythonTypeHints by lazy {
+    MicroPythonTypeHints("esp8266/latest")
+  }
 
   override val packageRequirements: List<PyRequirement> by lazy {
     PyRequirement.fromText("""pyserial>=3.3,<3.4""")

--- a/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniProDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/WemosD1MiniProDeviceProvider.kt
@@ -16,6 +16,7 @@
 
 package com.jetbrains.micropython.devices
 
+import com.jetbrains.micropython.settings.MicroPythonTypeHints
 import com.jetbrains.micropython.settings.MicroPythonUsbId
 import com.jetbrains.python.packaging.PyRequirement
 
@@ -31,6 +32,10 @@ class WemosD1MiniProDeviceProvider : MicroPythonDeviceProvider {
 
   override val documentationURL: String
     get() = "https://github.com/vlasovskikh/intellij-micropython/wiki/WEMOS-D1-mini-Pro"
+
+  override val typeHints: MicroPythonTypeHints by lazy {
+    MicroPythonTypeHints("esp8266/latest")
+  }
 
   override val packageRequirements: List<PyRequirement> by lazy {
     PyRequirement.fromText("""pyserial>=3.3,<3.4""")

--- a/typehints/esp8266/latest/esp.pyi
+++ b/typehints/esp8266/latest/esp.pyi
@@ -1,0 +1,70 @@
+
+from typing import Optional
+
+def sleep_type(sleep_type: Optional[int]) -> Optional[int]:
+    """
+    Get or set the sleep type.
+
+    If the sleep_type parameter is provided, sets the sleep type to its value.
+    If the function is called without parameters, returns the current sleep type.
+
+    The possible sleep types are defined as constants:
+
+    * ``SLEEP_NONE`` – all functions enabled,\n
+    * ``SLEEP_MODEM`` – modem sleep, shuts down the WiFi Modem circuit.\n
+    * ``SLEEP_LIGHT`` – light sleep, shuts down the WiFi Modem circuit and suspends the processor periodically.\n
+    The system enters the set sleep mode automatically when possible.
+
+    :param sleep_type: Sleep type.
+    :type sleep_type: int
+    :return: Current sleep type
+    :rtype: int
+    """
+
+def deepsleep(time: int = 0) -> None:
+    """
+    Enter deep sleep.
+
+    The whole module powers down, except for the RTC clock circuit, which can
+    be used to restart the module after the specified time if the pin 16 is
+    connected to the reset pin. Otherwise the module will sleep until manually reset.
+
+    :param time: Amount of time in milliseconds to sleep.
+    """
+
+def set_native_code_location(start: Optional[int], length: Optional[int]) -> None:
+    """
+    Set the location that native code will be placed for execution after it is
+    compiled. Native code is emitted when the ``@micropython.native``, ``@micropython.viper``
+    and ``@micropython.asm_xtensa`` decorators are applied to a function. The
+    ESP8266 must execute code from either iRAM or the lower 1MByte of flash
+    (which is memory mapped), and this function controls the location.
+
+    If start and length are both **None** then the native code location is
+    set to the unused portion of memory at the end of the iRAM1 region. The
+    size of this unused portion depends on the firmware and is typically
+    quite small (around 500 bytes), and is enough to store a few very small
+    functions. The advantage of using this iRAM1 region is that it does not
+    get worn out by writing to it.
+
+    If neither start nor length are None then they should be integers. start
+    should specify the byte offset from the beginning of the flash at which
+    native code should be stored. length specifies how many bytes of flash
+    from start can be used to store native code. start and length should be
+    multiples of the sector size (being 4096 bytes). The flash will be
+    automatically erased before writing to it so be sure to use a region of
+    flash that is not otherwise used, for example by the firmware or the filesystem.
+
+    When using the flash to store native code *start*+*length* must be less
+    than or  equal to 1MByte. Note that the flash can be worn out if repeated
+    erasures (and writes) are made so use this feature sparingly. In particular,
+    native code needs to be recompiled and rewritten to flash on each boot
+    (including wake from deepsleep).
+
+    In both cases above, using iRAM1 or flash, if there is no more room left in
+    the specified region then the use of a native decorator on a function will
+    lead to ``MemoryError`` exception being raised during compilation of that function.
+
+    :param start: Start of native code region.
+    :param length: End of native code region.
+    """

--- a/typehints/esp8266/latest/machine/__init__.pyi
+++ b/typehints/esp8266/latest/machine/__init__.pyi
@@ -1,0 +1,769 @@
+"""
+The ``machine`` module contains specific functions related to the hardware
+on a particular board. Most functions in this module allow to achieve
+direct and unrestricted access to and control of hardware blocks on a
+system (like CPU, timers, buses, etc.). Used incorrectly, this can
+lead to malfunction, lockups, crashes of your board, and in extreme
+cases, hardware damage.
+
+A note of callbacks used by functions and class methods of machine
+module: all these callbacks should be considered as executing in an
+interrupt context. This is true for both physical devices with
+IDs >= 0 and “virtual” devices with negative IDs like -1 (these
+“virtual” devices are still thin shims on top of real hardware
+and real hardware interrupts).
+"""
+
+
+from typing import Callable, Optional, Collection, Tuple, Union
+
+
+IDLE = int
+
+
+class Pin(object):
+
+    IRQ_FALLING = int
+    IRQ_RISING = int
+    IRQ_LOWLEVEL = int
+    IRQ_HIGHLEVEL = int
+    IN = int
+    OUT = int
+    OPEN_DRAIN = int
+    PULL_UP = int
+    PULL_DOWN = int
+    LOW_POWER = int
+    MED_POWER = int
+    HIGH_POWER = int
+
+    def init(self, value: int, drive: int, alt: int, mode: int = -1, pull: int = -1) -> None:
+        """
+        Re-initialise the pin using the given parameters. Only those arguments
+        that are specified will be set. The rest of the pin peripheral state
+        will remain unchanged. See the constructor documentation for details
+        of the arguments.
+
+        :param value: Initial output pin value.
+        :param drive: Output power of the pin.
+        :param alt: Alternate function for the pin.
+        :param mode: Pin mode.
+        :param pull: Flag that specifies if the pin has a (weak) pull resistor attached.
+        """
+        ...
+
+    def value(self, x: Optional[int]) -> Optional[int]:
+        """
+        This method allows to set and get the value of the pin, depending on
+        whether the argument **x** is supplied or not.
+
+        If the argument is omitted then this method gets the digital logic
+        level of the pin, returning 0 or 1 corresponding to low and high
+        voltage signals respectively. The behaviour of this method depends
+        on the mode of the pin:
+
+        * ``Pin.IN`` - The method returns the actual input value currently present on the pin.
+        * ``Pin.OUT`` - The behaviour and return value of the method is undefined.
+        * ``Pin.OPEN_DRAIN`` - If the pin is in state ‘0’ then the behaviour and return value of the method is undefined. Otherwise, if the pin is in state ‘1’, the method returns the actual input value currently present on the pin.
+
+        :param x: Value to set on a pin.
+        :return: Current value of a pin.
+        :rtype: int
+        """
+        ...
+
+    def __call__(self, x: Optional[int]) -> Optional[int]:
+        """
+        Pin objects are callable. The call method provides a (fast) shortcut
+        to set and get the value of the pin. It is equivalent to
+        Pin.value([x]). See ``Pin.value()`` for more details.
+
+        :param x: Value to set on a pin.
+        :return: Current value of a pin.
+        :rtype: int
+        """
+        ...
+
+    def on(self) -> None:
+        """
+        Set pin to “1” output level.
+        """
+        ...
+
+    def off(self) -> None:
+        """
+        Set pin to “0” output level.
+        """
+        ...
+
+    def mode(self, mode: Optional[int]) -> Optional[int]:
+        """
+        Get or set the pin mode.
+
+        **mode** can be one of following values:
+
+        * ``Pin.IN`` - Pin is configured for input. If viewed as an output the pin is in high-impedance state.
+
+        * ``Pin.OUT`` - Pin is configured for (normal) output.
+
+        * ``Pin.OPEN_DRAIN`` - Pin is configured for open-drain output. Open-drain output works in the following way: if the output value is set to 0 the pin is active at a low level; if the output value is 1 the pin is in a high-impedance state. Not all ports implement this mode, or some might only on certain pins.
+
+        * ``Pin.ALT`` - Pin is configured to perform an alternative function, which is port specific. For a pin configured in such a way any other Pin methods (except Pin.init()) are not applicable (calling them will lead to undefined, or a hardware-specific, result). Not all ports implement this mode.
+
+        * ``Pin.ALT_OPEN_DRAIN`` - The Same as Pin.ALT, but the pin is configured as open-drain. Not all ports implement this mode.
+
+        :param mode: Mode to be set on a pin.
+        :return: Current moded on a pin.
+        :rtype: int
+        """
+        ...
+
+    def pull(self, pull: Optional[int]) -> Optional[int]:
+        """
+        Get or set the pin pull state.
+
+        *pull* can be one of following values:
+
+        * ``None`` - No pull up or down resistor.
+        * ``Pin.PULL_UP`` - Pull up resistor enabled.
+        * ``Pin.PULL_DOWN`` - Pull down resistor enabled.
+
+        :param pull: Pull state.
+        :return: Current pull state.
+        :rtype: int
+        """
+        ...
+
+    def irq(self, handler: Callable[Pin] = None, trigger: int = (IRQ_FALLING | IRQ_RISING),
+            priority: int = 1, wake: int = None) -> Callable[None]:
+        """
+        Configure an interrupt handler to be called when the trigger source
+        of the pin is active.
+
+        If the pin mode is ``Pin.IN`` then the trigger
+        source is the external value on the pin.
+
+        If the pin mode is ``Pin.OUT`` then the trigger source is the output
+        buffer of the pin.
+
+        if the pin mode is ``Pin.OPEN_DRAIN`` then the trigger source is the
+        output buffer for state ‘0’ and the external pin value for state ‘1’.
+
+        Possible values for ``wake``:
+
+        * ``machine.IDLE``
+        * ``machine.SLEEP``
+        * ``machine.DEEPSLEEP``
+
+        Possible values for ``trigger``:
+
+        * ``Pin.IRQ_FALLING`` - interrupt on falling edge.
+        * ``Pin.IRQ_RISING`` - interrupt on rising edge.
+        * ``Pin.IRQ_LOW_LEVEL`` - interrupt on low level.
+        * ``Pin.IRQ_HIGH_LEVEL`` - interrupt on high level.
+
+        These values can be OR’ed together to trigger on multiple events.
+
+        :param handler: Interrupt handler.
+        :param trigger: Event which can generate an interrupt
+        :param priority: Priority level of the interrupt
+        :param wake: Power mode in which this interrupt can wake up the system
+        :return: Callback object.
+        :rtype: Callable[Pin]
+        """
+        ...
+
+
+class Signal(object):
+
+    def __init__(self, pin_obj: Pin, invert: bool = False) -> None:
+        """
+        Create a Signal object.
+
+        :param pin_obj: Existing Pin object.
+        :param invert: If True, the signal will be inverted (active low).
+        """
+        ...
+
+    def value(self, x: Optional[bool]) -> None:
+        """
+        This method allows to set and get the value of the signal, depending
+        on whether the argument x is supplied or not.
+
+        If the argument is omitted then this method gets the signal level, 1
+        meaning signal is asserted (active) and 0 - signal inactive.
+
+        If the argument is supplied then this method sets the signal level.
+        The argument x can be anything that converts to a boolean. If it
+        converts to True, the signal is active, otherwise it is inactive.
+
+        Correspondence between signal being active and actual logic level
+        on the underlying pin depends on whether signal is inverted
+        (active-low) or not. For non-inverted signal, active status
+        corresponds to logical 1, inactive - to logical 0. For
+        inverted/active-low signal, active status corresponds to
+        logical 0, while inactive - to logical 1.
+
+        :param x: Signal level (active or not).
+        :return: Signal level.
+        :rtype: int
+        """
+        ...
+
+    def on(self):
+        """
+        Activate signal.
+        """
+        ...
+
+    def off(self):
+        """
+        Deactivate signal.
+        """
+        ...
+
+
+class UART(object):
+
+    def __init__(self, id: int, baudrate: int = 115200) -> None:
+        """
+        Init UART object with a given baudrate.
+
+        :param id: ID of UART "object" (either 0 or 1).
+        :param baudrate: Rate of data transfer.
+        """
+
+    def init(self, baudrate: int, bits: int = 8, parity: Optional[int] = 0, stop: int = 1,
+             timeout: int = 0, timeout_char: int = 0) -> None:
+        """
+        Init with a given parameters.
+
+        :param baudrate: Baud rate, that specifies how fast data is sent over serial line.
+        :param bits: Bit length of data packet (can be 7, 8 or 9 depending on parity).
+        :param parity: Number of parity bits (can be 0 or 1).
+        :param stop: Length of stop bit (can be 1 or 2).
+        :param timeout: Timeout waiting for first char (in ms).
+        :param timeout_char: Timeout waiting between chars (in ms).
+        """
+        ...
+
+    def deinit(self) -> None:
+        """
+        Turn off the UART bus.
+        """
+        ...
+
+    def any(self) -> int:
+        """
+        Returns an integer counting the number of characters that can be read
+        without blocking. It will return 0 if there are no characters
+        available and a positive number if there are characters. The method
+        may return 1 even if there is more than one character available for reading.
+
+        :return: Number of characters that can be read without blocking.
+        :rtype: int
+        """
+        ...
+
+    def read(self, nbytes: Optional[int]) -> bytes:
+        """
+        Read characters. If ``nbytes`` is specified then read at most that many
+        bytes, otherwise read as much data as possible.
+
+        :param nbytes: Upper limit on number of read characters.
+        :return: Bytes read in.
+        :rtype: bytes
+        """
+        ...
+
+    def readinto(self, buf: bytearray, nbytes: Optional[int]) -> Optional[int]:
+        """
+        Read bytes into the ``buf``. If ``nbytes`` is specified then read at most
+        that many bytes. Otherwise, read at most ``len(buf)`` bytes.
+
+        :param buf: Buffer for holding read data.
+        :param nbytes: Upper limit on number of read characters.
+        :return: Number of bytes read in.
+        :rtype: Optional[int]
+        """
+        ...
+
+    def readline(self) -> Optional[bytes]:
+        """
+        Read a line, ending in a newline character.
+
+        :return: The line read or ``None`` on timeout.
+        :rtype: Optional[bytes]
+        """
+        ...
+
+    def write(self, buf: bytearray) -> Optional[int]:
+        """
+        Write the buffer of bytes to the bus.
+
+        :param buf: Data that needs to be written.
+        :return: Number of bytes written or ``None`` on timeout.
+        :rtype: Optional[int]
+        """
+        ...
+
+    def sendbreak(self) -> None:
+        """
+        Send a break condition on the bus. This drives the bus low for a
+        duration longer than required for a normal transmission of a character.
+        """
+
+
+class SPI(object):
+
+    LSB = int
+    MSB = int
+
+    def __init__(self, id: int) -> None:
+        """
+        Construct an SPI object on the given bus, ``id``. Values of id depend
+        on a particular port and its hardware. Values 0, 1, etc. are commonly
+        used to select hardware SPI block #0, #1, etc. Value -1 can be used
+        for bitbanging (software) implementation of SPI (if supported by a port).
+
+        With no additional parameters, the SPI object is created but not
+        initialised (it has the settings from the last initialisation of
+        the bus, if any). If extra arguments are given, the bus is
+        initialised. See init for parameters of initialisation.
+
+        :param id: Bus ID.
+        """
+        ...
+
+    def init(self, baudrate: int = 1000000, polarity: int = 0, phase: int = 0,
+             bits: int = 8, firstbit: int = MSB, sck: Optional[Pin] = None,
+             mosi: Optional[Pin] = None, miso: Optional[Pin] = None):
+        """
+        Initialise the SPI bus with the given parameters.
+
+        :param baudrate: SCK clock rate.
+        :param polarity: Level the idle clock line sits at (0 or 1).
+        :param phase: Sample data on the first or second clock edge respectively (0 or 1).
+        :param bits: Width in bits of each transfer.
+        :param firstbit: Can be ``SPI.MSB`` or ``SPI.LSB``.
+        :param sck: SCK pin.
+        :param mosi: MOSI pin.
+        :param miso: MISO pin.
+        """
+        ...
+
+    def deinit(self) -> None:
+        """
+        Turn off the SPI bus.
+        """
+        ...
+
+    def read(self, nbytes: int, write: int = 0x00) -> bytes:
+        """
+        Read a number of bytes specified by ``nbytes`` while continuously
+        writing the single byte given by ``write``. Returns a ``bytes``
+        object with the data that was read.
+
+        :param nbytes: Number of characters to read.
+        :param write: Value to continiously write while reading data.
+        :return: Bytes read in.
+        :rtype: bytes
+        """
+        ...
+
+    def readinto(self, buf: bytearray, write: int = 0x00) -> None:
+        """
+        Read into the buffer specified by ``buf`` while continuously writing
+        the single byte given by ``write``.
+
+        :param nbytes: Number of characters to read.
+        :param write: Value to continiously write while reading data.
+        """
+        ...
+
+    def write(self, buf: bytes) -> None:
+        """
+        Write the bytes contained in ``buf``.
+
+        :param buf: Bytes to write.
+        """
+        ...
+
+    def write_readinto(self, write_buf: bytearray, read_buf: bytearray) -> None:
+        """
+        Write the bytes from ``write_buf`` while reading into ``read_buf``. The
+        buffers can be the same or different, but both buffers must have
+        the same length.
+
+        :param write_buf: Buffer to read data into.
+        :param read_buf: Buffer to write data from.
+        """
+        ...
+
+
+class I2C(object):
+    def __init__(self, id: int, *, scl: Pin, sda: Pin, freq: int = 400000) -> None:
+        """
+        Construct and return a new I2C object.
+
+        :param id: Particular I2C peripheral (-1 for software implementation).
+        :param scl: Pin object specifying the pin to use for SCL.
+        :param sda: Pin object specifying the pin to use for SDA.
+        :param freq: Maximum frequency for SCL.
+        """
+        ...
+
+    def init(self, scl: Pin, sda: Pin, *, freq: int = 400000) -> None:
+        """
+        Initialise the I2C bus with the given arguments.
+
+        :param scl: Pin object specifying the pin to use for SCL.
+        :param sda: Pin object specifying the pin to use for SDA.
+        :param freq: Maximum frequency for SCL.
+        """
+        ...
+
+    def scan(self) -> Collection[int]:
+        """
+        Scan all I2C addresses between *0x08* and *0x77* inclusive and return a
+        list of those that respond. A device responds if it pulls the SDA
+        line low after its address (including a write bit) is sent on the bus.
+        :return:
+        """
+        ...
+
+    def start(self) -> None:
+        """
+        Generate a START condition on the bus (SDA transitions to low while SCL is high).
+        """
+        ...
+
+    def stop(self) -> None:
+        """
+        Generate a STOP condition on the bus (SDA transitions to high while SCL is high).
+        """
+        ...
+
+    def readinto(self, buf: bytearray, nack: bool = True) -> None:
+        """
+        Reads bytes from the bus and stores them into ``buf``. The number of bytes
+        read is the length of ``buf``. An **ACK** will be sent on the bus after
+        receiving all but the last byte. After the last byte is received,
+        if ``nack`` is true then a **NACK** will be sent, otherwise an **ACK** will be
+        sent (and in this case the slave assumes more bytes are going to be
+        read in a later call).
+
+        :param buf: Buffer to read bytes into.
+        :param nack: If true, then NACK will be sent after reading last bytes.
+        """
+        ...
+
+    def write(self, buf: bytearray) -> None:
+        """
+        Write the bytes from ``buf`` to the bus. Checks that an **ACK** is received
+        after each byte and stops transmitting the remaining bytes if a
+        **NACK** is received. The function returns the number of ACKs that
+        were received.
+
+        :param buf: Buffer to write bytes from.
+        """
+
+    def readfrom(self, addr: int, nbytes: int, stop: bool = True) -> bytes:
+        """
+        Read ``nbytes`` from the slave specified by ``addr``.
+
+        :param addr: Address of slave device.
+        :param nbytes: Maximum amount of bytes to be read.
+        :param stop: If true, then STOP condition is generated at the end of the transfer.
+        :return: Data read.
+        :rtype: bytes
+        """
+        ...
+
+    def readfrom_into(self, addr: int, buf: bytearray, stop: bool = True) -> None:
+        """
+        Read into ``buf`` from the slave specified by ``addr``. The number of
+        bytes read will be the length of buf. If ``stop`` is true then a **STOP**
+        condition is generated at the end of the transfer.
+
+        :param addr: Address of slave device.
+        :param buf: Buffer for storing read data.
+        :param stop: If true, then STOP condition is generated at the end of the transfer.
+        """
+        ...
+
+    def writeto(self, addr: int, buf: bytearray, stop: bool = True) -> None:
+        """
+        Write the bytes from ``buf`` to the slave specified by ``addr``. If a **NACK** is
+        received following the write of a byte from buf then the remaining
+        bytes are not sent. If stop is true then a **STOP** condition is generated
+        at the end of the transfer, even if a **NACK** is received.
+
+        :param addr: Address of slave device.
+        :param buf: Buffer to write data from.
+        :param stop: If true, then STOP condition is generated at the end of the transfer.
+        :return: Number of ACKs that were received.
+        """
+        ...
+
+    def readfrom_mem(self, addr: int, memaddr: int, addrsize: int = 8) -> bytes:
+        """
+        Read ``nbytes`` from the slave specified by ``addr`` starting from the memory
+        address specified by ``memaddr``. The argument ``addrsize`` specifies the
+        address size in bits. Returns a bytes object with the data read.
+
+        :param addr: Address of slave device.
+        :param memaddr: Memory address location on a slave device to read from.
+        :param addrsize: Address size in bits.
+        :return: Data that has been read.
+        :rtype: bytes
+        """
+        ...
+
+    def readfrom_mem_into(self, addr: int, memaddr: int, buf, *, addrsize=8) -> None:
+        """
+        Read into ``buf`` from the slave specified by addr starting from the memory
+        address specified by ``memaddr``. The number of bytes read is the length
+        of ``buf``. The argument ``addrsize`` specifies the address size in bits
+        (on ESP8266 this argument is not recognised and the address size is
+        always 8 bits).
+
+        :param addr: Address of slave device.
+        :param memaddr: Memory address location on a slave device to write into.
+        :param buf: Buffer to store read data.
+        :param addrsize: Address size in bits.
+        """
+        ...
+
+    def writeto_mem(self, addr: int, memaddr: int, *, addrsize=8) -> None:
+        """
+        Write ``buf`` to the slave specified by ``addr`` starting from the
+        memory address specified by ``memaddr``. The argument ``addrsize`` specifies
+        the address size in bits (on ESP8266 this argument is not recognised
+        and the address size is always 8 bits).
+
+        :param addr: Address of slave device.
+        :param memaddr: Memory address location on a slave device to write into.
+        :param addrsize: Address size in bits.
+        """
+        ...
+
+
+class RTC(object):
+
+    def __init__(self, id: int = 0) -> None:
+        """
+        Create an RTC object.
+
+        :param id: ID of RTC device.
+        """
+        ...
+
+    def init(self, datetime: Tuple) -> None:
+        """
+        Initialise the RTC. Datetime is a tuple of the form:
+
+        ``(year, month, day[, hour[, minute[, second[, microsecond[, tzinfo]]]]])``
+
+        :param datetime: Tuple with information regarding desired initial date.
+        """
+        ...
+
+    def now(self) -> Tuple:
+        """
+        Get get the current datetime tuple.
+
+        :return: Current datetime tuple.
+        :rtype: tuple
+        """
+        ...
+
+    def deinit(self) -> None:
+        """
+        Resets the RTC to the time of January 1, 2015 and starts running it again.
+        """
+        ...
+
+    def alarm(self, id: int, time: Union[int, Tuple], *, repeat: bool = False) -> None:
+        """
+        Set the RTC alarm. Time might be either a millisecond value to program the
+        alarm to current ``time + time_in_ms`` in the future, or a ``datetimetuple``.
+        If the ``time`` passed is in milliseconds, repeat can be set to True to
+        make the alarm periodic.
+
+        :param id: Alarm ID.
+        :param time: Either timestamp in milliseconds or datetime tuple, describing desired moment in the future.
+        :param repeat: Make alarm periodic, if time passed as milliseconds.
+        """
+        ...
+
+    def alarm_left(self, alarm_id: int = 0) -> int:
+        """
+        Get the number of milliseconds left before the alarm expires.
+
+        :param alarm_id: Alarm ID.
+        :return: Tumber of milliseconds left before the alarm expires.
+        :rtype: int
+        """
+        ...
+
+    def cancel(self, alarm_id: int = 0) -> None:
+        """
+        Cancel a running alarm.
+
+        :param alarm_id: Alarm ID.
+        """
+        ...
+
+    def irq(self, *, trigger: int, handler: Callable = None, wake: int = IDLE) -> None:
+        """
+        Create an irq object triggered by a real time clock alarm.
+
+        :param trigger: Must be ``RTC.ALARM0``.
+        :param handler: Function to be called when the callback is triggered.
+        :param wake: Sleep mode from where this interrupt can wake up the system.
+        """
+        ...
+
+    ALARM0 = int
+
+
+class Timer(object):
+    ONE_SHOT = int
+    PERIODIC = int
+
+    def __init__(self, id):
+        """
+        Construct a new timer object of the given id. Id of -1 constructs a
+        virtual timer (if supported by a board).
+
+        :param id: Timer ID.
+        """
+
+    def deinit(self) -> None:
+        """
+        Deinitialises the timer. Stops the timer, and disables the timer peripheral.
+        """
+        ...
+
+
+def reset() -> None:
+    """
+    Resets the device in a manner similar to pushing the external RESET button.
+    """
+    ...
+
+def reset_cause() -> int:
+    """
+    Get the reset cause. Below are possible return values:
+
+    * ``machine.PWRON_RESET``
+    * ``machine.HARD_RESET``
+    * ``machine.WDT_RESET``
+    * ``machine.DEEPSLEEP_RESET``
+    * ``machine.SOFT_RESET``
+
+    :return: Reset cause.
+    :rtype: int
+    """
+    ...
+
+def disable_irq() -> int:
+    """
+    Disable interrupt requests. Returns the previous IRQ state which should
+    be considered an opaque value. This return value should be passed to
+    the ``enable_irq`` function to restore interrupts to their original state,
+    before ``disable_irq`` was called.
+
+    :return: Previous IRQ state.
+    :rtype: int
+    """
+    ...
+
+def enable_irq(state: int) -> None:
+    """
+    Re-enable interrupt requests. The state parameter should be the value
+    that was returned from the most recent call to the ``disable_irq`` function.
+
+    :param state: IRQ state, previously returned from ``disable_irq`` function.
+    """
+    ...
+
+def freq() -> int:
+    """
+    Returns CPU frequency in hertz.
+
+    :return: CPU frequency in hertz.
+    :rtype: int
+    """
+
+def idle() -> None:
+    """
+    Gates the clock to the CPU, useful to reduce power consumption at any time
+    during short or long periods. Peripherals continue working and execution
+    resumes as soon as any interrupt is triggered (on many ports this includes
+    system timer interrupt occurring at regular intervals on the order of millisecond).
+    """
+
+def sleep() -> None:
+    """
+    Stops the CPU and disables all peripherals except for WLAN. Execution is
+    resumed from the point where the sleep was requested. For wake up to
+    actually happen, wake sources should be configured first.
+    """
+
+def deepsleep() -> None:
+    """
+    Stops the CPU and all peripherals (including networking interfaces, if
+    any). Execution is resumed from the main script, just as with a reset.
+    The reset cause can be checked to know that we are coming from
+    ``machine.DEEPSLEEP``. For wake up to actually happen, wake
+    sources should be configured first, like Pin change or RTC timeout.
+    """
+
+def wake_reason() -> int:
+    """
+    Get the wake reason. Possible values are:
+
+    * ``machine.WLAN_WAKE``
+    * ``machine.PIN_WAKE``
+    * ``machine.RTC_WAKE``
+
+    :return: Wake reason.
+    :rtype: int
+    """
+    ...
+
+def unique_id() -> bytearray:
+    """
+    Returns a byte string with a unique identifier of a board/SoC. It will
+    vary from a board/SoC instance to another, if underlying hardware allows.
+    Length varies by hardware (so use substring of a full value if you expect
+    a short ID). In some MicroPython ports, ID corresponds to the network MAC address.
+    :return: Unique identifier of a board/SoC.
+    :rtype: bytearray
+    """
+    ...
+
+def time_pulse_us(pin: Pin, pulse_level: int, timeout_us: int = 1000000) -> int:
+    """
+    Time a pulse on the given pin, and return the duration of the pulse in
+    microseconds. The pulse_level argument should be 0 to time a low pulse
+    or 1 to time a high pulse.
+
+    If the current input value of the pin is different to pulse_level, the
+    function first (*) waits until the pin input becomes equal to pulse_level,
+    then (**) times the duration that the pin is equal to pulse_level. If the
+    pin is already equal to pulse_level then timing starts straight away.
+
+    The function will return **-2** if there was timeout waiting for condition marked
+    (*) above, and **-1** if there was timeout during the main measurement, marked (**)
+    above. The timeout is the same for both cases and given by timeout_us
+    (which is in microseconds).
+
+    :param pin: Pin for timing a pulse on.
+    :param pulse_level: Level of pulse (*1* for high, *0* for low)
+    :param timeout_us: Duration of wait for pin change conditions, in microsecond.
+    :return: Result code (-1 or -2)
+    :rtype: int
+    """
+    ...

--- a/typehints/esp8266/latest/utime.pyi
+++ b/typehints/esp8266/latest/utime.pyi
@@ -1,0 +1,191 @@
+"""
+This module implements a subset of the corresponding CPython module, as
+described below. For more information, refer to the original CPython
+documentation: ``time``.
+
+The ``utime`` module provides functions for getting the current time and
+date, measuring time intervals, and for delays.
+
+Time Epoch: Unix port uses standard for POSIX systems epoch of **1970-01-01 00:00:00 UTC**.
+However, embedded ports use epoch of **2000-01-01 00:00:00 UTC**.
+
+Maintaining actual calendar date/time: This requires a Real Time Clock (RTC). On systems
+with underlying OS (including some RTOS), an RTC may be implicit. Setting and maintaining
+actual calendar time is responsibility of OS/RTOS and is done outside of MicroPython, it
+just uses OS API to query date/time. On baremetal ports however system time depends on
+``machine.RTC() object``. The current calendar time may be set using
+``machine.RTC().datetime(tuple)`` function, and maintained by following means:
+
+* By a backup battery (which may be an additional, optional component for a particular board).
+* Using networked time protocol (requires setup by a port/user).
+* Set manually by a user on each power-up (many boards then maintain RTC time across hard resets, though some may require setting it again in such case).
+
+If actual calendar time is not maintained with a system/MicroPython RTC,
+functions below which require reference to current absolute time may
+behave not as expected.
+"""
+
+from typing import Optional
+
+
+def sleep_ms(ms: int) -> None:
+    """
+    Delay for given number of milliseconds, should be positive or 0.
+
+    :param ms: Delay in milliseconds
+    :type ms: int
+    """
+    ...
+
+def sleep_us(us: int) -> None:
+    """
+    Delay for given number of microseconds, should be positive or 0.
+
+    :param us: Delay in microseconds
+    :type us: int
+    """
+    ...
+
+def ticks_ms() -> int:
+    """Returns an increasing millisecond counter with an arbitrary reference
+    point, that wraps around after some value.
+
+    The wrap-around value is not explicitly exposed, but we will refer to it
+    as TICKS_MAX to simplify discussion. Period of the values is
+    TICKS_PERIOD = TICKS_MAX + 1. TICKS_PERIOD is guaranteed to be a power
+    of two, but otherwise may differ from port to port. The same period value
+    is used for all of ticks_ms(), ticks_us(), ticks_cpu() functions
+    (for simplicity). Thus, these functions will return a value in range
+    [0 .. TICKS_MAX], inclusive, total TICKS_PERIOD values. Note that only
+    non-negative values are used. For the most part, you should treat values
+    returned by these functions as opaque. The only operations available for
+    them are ticks_diff() and ticks_add() functions described below.
+
+    Note: Performing standard mathematical operations (+, -) or relational
+    operators (<, <=, >, >=) directly on these value will lead to invalid
+    result. Performing mathematical operations and then passing their results
+    as arguments to ticks_diff() or ticks_add() will also lead to invalid
+    results from the latter functions.
+    """
+    ...
+
+def ticks_us() -> int:
+    """Returns an increasing microsecond counter with an arbitrary reference
+    point, that wraps around after some value.
+
+    The wrap-around value is not explicitly exposed, but we will refer to it
+    as *TICKS_MAX* to simplify discussion. Period of the values is
+    *TICKS_PERIOD = TICKS_MAX + 1*. *TICKS_PERIOD* is guaranteed to be a power
+    of two, but otherwise may differ from port to port. The same period value
+    is used for all of ``ticks_ms()``, ``ticks_us()``, ``ticks_cpu()`` functions
+    (for simplicity). Thus, these functions will return a value in range
+    *[0 .. TICKS_MAX]*, inclusive, total *TICKS_PERIOD* values. Note that only
+    non-negative values are used. For the most part, you should treat values
+    returned by these functions as opaque. The only operations available for
+    them are ticks_diff() and ticks_add() functions described below.
+
+    Note: Performing standard mathematical operations (+, -) or relational
+    operators (<, <=, >, >=) directly on these value will lead to invalid
+    result. Performing mathematical operations and then passing their results
+    as arguments to ticks_diff() or ticks_add() will also lead to invalid
+    results from the latter functions."""
+    ...
+
+def ticks_cpu() -> int:
+    """Similar to ``ticks_ms()`` and ``ticks_us()``, but with the highest possible
+    resolution in the system. This is usually CPU clocks, and that’s why the
+    function is named that way. But it doesn’t have to be a CPU clock, some
+    other timing source available in a system (e.g. high-resolution timer)
+    can be used instead. The exact timing unit (resolution) of this function
+    is not specified on ``utime`` module level, but documentation for a specific
+    port may provide more specific information. This function is intended for
+     very fine benchmarking or very tight real-time loops. Avoid using it in
+     portable code."""
+
+def localtime(secs: Optional[int]) -> Tuple:
+    """
+    Convert a time expressed in seconds since the Epoch (see above) into an
+    8-tuple which contains: (year, month, mday, hour, minute, second, weekday,
+    yearday). If secs is not provided or None, then the current time from the RTC is used.
+
+    Tuple constraints:
+    * **year** includes the century (for example 2014).
+    *
+
+    :param secs:
+    :return:
+    """
+    ...
+
+def localtime(secs: Optional[int] = None) -> Tuple:
+    """
+    Convert a time expressed in seconds since the Epoch (see above) into an
+    8-tuple which contains: (year, month, mday, hour, minute, second, weekday,
+    yearday). If secs is not provided or None, then the current time from the
+    RTC is used.
+
+    Tuple constraints:
+
+    * **year** includes the century (for example 2014).
+    * **month** is *1-12*
+    * **mday** is *1-31*
+    * **hour** is *0-23*
+    * **minute** is *0-59*
+    * **second** is *0-59*
+    * **weekday** is *0-6* for *Mon-Sun*
+    * **yearday** is *1-366*
+
+    :param secs: Specific moment in time, expressed in seconds since Epoch.
+    :return: Tuple with decoded time information.
+    :rtype: tuple
+    """
+    ...
+
+def mktime(time: tuple) -> int:
+    """
+    This is inverse function of localtime. It’s argument is a full 8-tuple
+    which expresses a time as per localtime. It returns an integer which
+    is the number of seconds since Jan 1, 2000.
+
+    :param time: Full 8-tuple which expresses a time as per localtime.
+    :return: Amount of seconds since Epoch.
+    :rtype: int
+    """
+    ...
+
+def sleep(seconds: int) -> None:
+    """
+    Sleep for the given number of seconds. Some boards may accept seconds
+    as a floating-point number to sleep for a fractional number of seconds.
+    Note that other boards may not accept a floating-point argument, for
+    compatibility with them use ``sleep_ms()`` and ``sleep_us()`` functions.
+
+    :param seconds: Amount of time to sleep for.
+    """
+    ...
+
+def time() -> int:
+    """
+    Returns the number of seconds, as an integer, since the Epoch, assuming
+    that underlying RTC is set and maintained as described above. If an RTC
+    is not set, this function returns number of seconds since a port-specific
+    reference point in time (for embedded boards without a battery-backed RTC,
+    usually since power up or reset). If you want to develop portable
+    MicroPython application, you should not rely on this function to provide
+    higher than second precision. If you need higher precision, use ``ticks_ms()``
+    and ``ticks_us()`` functions, if you need calendar time, ``localtime()``
+    without an argument is a better choice.
+
+    In CPython, this function returns number of seconds since Unix epoch,
+    **1970-01-01 00:00 UTC**, as a floating-point, usually having microsecond
+    precision. With MicroPython, only Unix port uses the same Epoch, and if
+    floating-point precision allows, returns sub-second precision. Embedded
+    hardware usually doesn’t have floating-point precision to represent both
+    long time ranges and subsecond precision, so they use integer value with
+    second precision. Some embedded hardware also lacks battery-powered RTC,
+    so returns number of seconds since last power-up or from other relative,
+    hardware-specific point (e.g. reset).
+
+    :return: Number of seconds, as an integer, since the Epoch.
+    """
+    ...


### PR DESCRIPTION
First morsels of type hints for MicroPython-specific library `machine`, `utime` (reimplementation of standard Python module `time`) and ESP8266-specific `esp` module (documented functions only).

It was rather challenging experience, mostly because MicroPython (at least ESP8266 branch) could use some work. At some point, I've decided to take the liberty of redacting away functions that are specific for other ports and port-specific quirks in behavior (looking at you, WiPy). In addition to that, some default values and parameters were gleaned from reading C code for ESP8266 port.

This is very much a work in progress, I'll try to add modules and update existing ones as my knowledge of Python typing increases (fingers crossed!).

Some thoughts:

* At the moment type hints are segregated by platform (`microbit` and `esp8266`) and that's fine for board-specific modules, but there are many modules that are not changed between ports and will duplicate between different folders. This could lead to a usual host of problems associated with code duplication. Maybe we should use separate locations for board-specific modules and "standard library"?
* At the same time, even modules that are supposed to be shared between ports have places with different behavior depending on board they are executing on. For example, some functions return number of bytes read on WiPy but `None` on other boards. This presents problems with describing function signature, and will only get worse with time.

Still, it was somewhat fun. :)