### PR TITLE
Fixes for pin hints and some cleanup

### DIFF
--- a/typehints/microbit/microbit/__init__.pyi
+++ b/typehints/microbit/microbit/__init__.pyi
@@ -144,23 +144,6 @@ class MicroBitAnalogDigitalPin(MicroBitDigitalPin):
         between 0 (meaning 0V) and 1023 (meaning 3.3V).
         """
 
-    def write_analog(self, value: int) -> None:
-        """Output a PWM signal on the pin, with the duty cycle proportional to
-        the provided ``value``. The ``value`` may be either an integer or a
-        floating point number between 0 (0% duty cycle) and 1023 (100% duty).
-        """
-
-    def set_analog_period(self, period: int) -> None:
-        """Set the period of the PWM signal being output to ``period`` in
-        milliseconds. The minimum valid value is 1ms.
-        """
-
-    def set_analog_period_microseconds(self, period: int) -> None:
-        """Set the period of the PWM signal being output to ``period`` in
-        microseconds. The minimum valid value is 35µs.
-        """
-
-
 class MicroBitTouchPin(MicroBitAnalogDigitalPin):
     def is_touched(self) -> bool:
         """Return ``True`` if the pin is being touched with a finger, otherwise
@@ -175,20 +158,10 @@ class MicroBitTouchPin(MicroBitAnalogDigitalPin):
 pin0: MicroBitTouchPin
 """Pad 0."""
 
-pin0: MicroBitAnalogDigitalPin
-"""Pad 0."""
-
-
 pin1: MicroBitTouchPin
 """Pad 1."""
 
-pin1: MicroBitAnalogDigitalPin
-"""Pad 1."""
-
 pin2: MicroBitTouchPin
-"""Pad 2."""
-
-pin2: MicroBitAnalogDigitalPin
 """Pad 2."""
 
 pin3: MicroBitAnalogDigitalPin

--- a/typehints/microbit/microbit/__init__.pyi
+++ b/typehints/microbit/microbit/__init__.pyi
@@ -106,22 +106,37 @@ class MicroBitDigitalPin:
     ``set_pull`` to change the pull mode from the default.
     """
 
-    PULL_UP: int
-    PULL_DOWN: int
-    NO_PULL: int
+    NO_PULL: int = 0
+    PULL_UP: int = 1
+    PULL_DOWN: int = 2
 
     def read_digital(self) -> int:
         """Return 1 if the pin is high, and 0 if it's low."""
 
-    def write_digital(self, value: int) -> None:
-        """Set the pin to high if ``value`` is 1, or to low, if it is 0."""
-
-    def set_pull(self, value: int) -> None:
+    def set_pull(self, value: int = (NO_PULL or PULL_UP or PULL_DOWN)) -> None:
         """Set the pull state to one of three possible values: ``pin.PULL_UP``,
         ``pin.PULL_DOWN`` or ``pin.NO_PULL`` (where ``pin`` is an instance of
         a pin). See below for discussion of default pull states.
         """
 
+    def write_digital(self, value: int) -> None:
+        """Set the pin to high if ``value`` is 1, or to low, if it is 0."""
+
+    def write_analog(self, value: int) -> None:
+        """Output a PWM signal on the pin, with the duty cycle proportional to
+        the provided ``value``. The ``value`` may be either an integer or a
+        floating point number between 0 (0% duty cycle) and 1023 (100% duty).
+        """
+
+    def set_analog_period(self, period: int) -> None:
+        """Set the period of the PWM signal being output to ``period`` in
+        milliseconds. The minimum valid value is 1ms.
+        """
+
+    def set_analog_period_microseconds(self, period: int) -> None:
+        """Set the period of the PWM signal being output to ``period`` in
+        microseconds. The minimum valid value is 35µs.
+        """
 
 class MicroBitAnalogDigitalPin(MicroBitDigitalPin):
     def read_analog(self) -> int:
@@ -160,10 +175,20 @@ class MicroBitTouchPin(MicroBitAnalogDigitalPin):
 pin0: MicroBitTouchPin
 """Pad 0."""
 
+pin0: MicroBitAnalogDigitalPin
+"""Pad 0."""
+
+
 pin1: MicroBitTouchPin
 """Pad 1."""
 
+pin1: MicroBitAnalogDigitalPin
+"""Pad 1."""
+
 pin2: MicroBitTouchPin
+"""Pad 2."""
+
+pin2: MicroBitAnalogDigitalPin
 """Pad 2."""
 
 pin3: MicroBitAnalogDigitalPin

--- a/typehints/microbit/microbit/display.pyi
+++ b/typehints/microbit/microbit/display.pyi
@@ -10,7 +10,7 @@ you can use::
 """
 
 from . import Image
-from typing import overload
+from typing import overload, Iterable
 
 def get_pixel(x: int, y: int) -> int:
     """Return the brightness of the LED at column ``x`` and row ``y`` as an

--- a/typehints/microbit/microbit/i2c.pyi
+++ b/typehints/microbit/microbit/i2c.pyi
@@ -22,7 +22,7 @@ particularly long wires or large number of devices you may need to add
 additional pull-up resistors, to ensure noise-free communication.
 """
 
-
+from . import pin19, pin20
 from typing import Union
 
 


### PR DESCRIPTION
The pins were not being accurately represented. For example, write_analog does not appear in the hints. For i2c, pin19 and pin 20 were not being imported.