### PR TITLE
Added exclude support for Pyboard upload script

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
@@ -20,12 +20,16 @@ import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.OSProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VfsUtil
 import com.jetbrains.micropython.run.MicroPythonRunConfiguration
 import com.jetbrains.micropython.settings.MicroPythonFacet
 import com.jetbrains.micropython.settings.MicroPythonTypeHints
 import com.jetbrains.micropython.settings.MicroPythonUsbId
 import com.jetbrains.micropython.settings.microPythonFacet
 import com.jetbrains.python.packaging.PyRequirement
+import java.nio.file.Paths
 
 /**
  * @author stefanhoelzl
@@ -52,19 +56,33 @@ class PyboardDeviceProvider : MicroPythonDeviceProvider {
 
   override fun getRunCommandLineState(configuration: MicroPythonRunConfiguration,
                                       environment: ExecutionEnvironment): CommandLineState? {
+    val module = configuration.module ?: return null
     val facet = configuration.module?.microPythonFacet ?: return null
     val pythonPath = facet.pythonPath ?: return null
     val devicePath = facet.devicePath ?: return null
     val rootPath = configuration.project.basePath ?: return null
+    val file = StandardFileSystems.local().findFileByPath(configuration.path) ?: return null
+    val excludeRoots = ModuleRootManager.getInstance(module).excludeRoots
+    val excludes = excludeRoots
+            .asSequence()
+            .filter { VfsUtil.isAncestor(file, it, false) }
+            .filterNotNull()
+            .map { listOf("-X", it.path) }
+            .flatten()
+            .toList()
+    val excludeFiles = ModuleRootManager.getInstance(module).contentEntries
+            .asSequence()
+            .filterNotNull()
+            .map { it.excludePatterns.map { Paths.get(rootPath, it).toString() } }
+            .flatten()
+            .map { listOf("-X", it) }
+            .flatten()
+            .toList()
+    val command = listOf(pythonPath, "${MicroPythonFacet.scriptsPath}/microupload.py", "-C", rootPath) +
+            excludes + excludeFiles + listOf("-v", devicePath, configuration.path)
     return object : CommandLineState(environment) {
       override fun startProcess() =
-          OSProcessHandler(GeneralCommandLine(pythonPath,
-                                              "${MicroPythonFacet.scriptsPath}/microupload.py",
-                                              "-C",
-                                              rootPath,
-                                              "-v",
-                                              devicePath,
-                                              configuration.path))
+          OSProcessHandler(GeneralCommandLine(command))
     }
   }
 }


### PR DESCRIPTION
PyboardDeviceProvider now recognizes two settings from project structure:
- Excluded folders (marked by red)
- Exclude files (it will simply append those filenames to the project basedir)
It allows to effectively exclude:
- .git folder
- .idea folder
- any other files unwanted for deployment (README.md for example)
Tested with
PyCharm 2018.1.2 (Professional Edition)
Build #PY-181.4668.75, built on April 25, 2018
JRE: 1.8.0_152-release-1136-b29 amd64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Linux 4.15.0-20-generic

Providers for other devices like ESP8266 could also benefit from this update. But I'm not that comfortable with Intellij Plugin SDK to dare to interfere with what's already working :)