### PR TITLE
Fixed pyboard device provider to also respect excluded folders

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/devices/Esp8266DeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/Esp8266DeviceProvider.kt
@@ -1,26 +1,12 @@
 package com.jetbrains.micropython.devices
 
-import com.intellij.execution.configurations.CommandLineState
-import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.OSProcessHandler
-import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.vfs.StandardFileSystems
-import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.openapi.vfs.VfsUtilCore
-import com.jetbrains.micropython.run.MicroPythonRunConfiguration
-import com.jetbrains.micropython.settings.MicroPythonFacet
 import com.jetbrains.micropython.settings.MicroPythonTypeHints
 import com.jetbrains.micropython.settings.MicroPythonUsbId
-import com.jetbrains.micropython.settings.microPythonFacet
-import com.jetbrains.python.packaging.PyPackageManager
-import com.jetbrains.python.packaging.PyRequirement
 
 /**
  * @author vlan
  */
-class Esp8266DeviceProvider : MicroPythonDeviceProvider {
+class Esp8266DeviceProvider : MicrouploadDeviceProvider() {
   override val persistentName: String
     get() = "ESP8266"
 
@@ -33,39 +19,5 @@ class Esp8266DeviceProvider : MicroPythonDeviceProvider {
 
   override val typeHints: MicroPythonTypeHints by lazy {
     MicroPythonTypeHints(listOf("stdlib", "micropython", "esp8266"))
-  }
-
-  override fun getPackageRequirements(sdk: Sdk): List<PyRequirement> {
-    val manager = PyPackageManager.getInstance(sdk)
-    return manager.parseRequirements("""|pyserial>=3.3,<4.0
-                                        |docopt>=0.6.2,<0.7
-                                        |adafruit-ampy>=1.0.5,<1.1""".trimMargin())
-  }
-
-  override fun getRunCommandLineState(configuration: MicroPythonRunConfiguration,
-                                      environment: ExecutionEnvironment): CommandLineState? {
-    val module = configuration.module ?: return null
-    val facet = module.microPythonFacet ?: return null
-    val pythonPath = facet.pythonPath ?: return null
-    val devicePath = facet.devicePath ?: return null
-    val rootPath = configuration.project.basePath ?: return null
-    val rootDir = StandardFileSystems.local().findFileByPath(rootPath) ?: return null
-    val file = StandardFileSystems.local().findFileByPath(configuration.path) ?: return null
-    val excludeRoots = ModuleRootManager.getInstance(module).excludeRoots
-    val excludes = excludeRoots
-        .asSequence()
-        .filter { VfsUtil.isAncestor(file, it, false) }
-        .map { VfsUtilCore.getRelativePath(it, rootDir) }
-        .filterNotNull()
-        .map { listOf("-X", it) }
-        .flatten()
-        .toList()
-    val command = listOf(pythonPath, "${MicroPythonFacet.scriptsPath}/microupload.py", "-C", rootPath) +
-        excludes + listOf("-v", devicePath, configuration.path)
-
-    return object : CommandLineState(environment) {
-      override fun startProcess() =
-          OSProcessHandler(GeneralCommandLine(command))
-    }
   }
 }

--- a/src/main/kotlin/com/jetbrains/micropython/devices/MicrouploadDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/MicrouploadDeviceProvider.kt
@@ -1,0 +1,52 @@
+package com.jetbrains.micropython.devices
+
+import com.intellij.execution.configurations.CommandLineState
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.OSProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.jetbrains.micropython.run.MicroPythonRunConfiguration
+import com.jetbrains.micropython.settings.MicroPythonFacet
+import com.jetbrains.micropython.settings.microPythonFacet
+import com.jetbrains.python.packaging.PyPackageManager
+import com.jetbrains.python.packaging.PyRequirement
+
+abstract class MicrouploadDeviceProvider : MicroPythonDeviceProvider {
+  override fun getPackageRequirements(sdk: Sdk): List<PyRequirement> {
+    val manager = PyPackageManager.getInstance(sdk)
+    return manager.parseRequirements("""|pyserial>=3.3,<4.0
+                                          |docopt>=0.6.2,<0.7
+                                          |adafruit-ampy>=1.0.5,<1.1""".trimMargin())
+  }
+
+  override fun getRunCommandLineState(configuration: MicroPythonRunConfiguration,
+                                      environment: ExecutionEnvironment): CommandLineState? {
+    val module = configuration.module ?: return null
+    val facet = module.microPythonFacet ?: return null
+    val pythonPath = facet.pythonPath ?: return null
+    val devicePath = facet.devicePath ?: return null
+    val rootPath = configuration.project.basePath ?: return null
+    val rootDir = StandardFileSystems.local().findFileByPath(rootPath) ?: return null
+    val file = StandardFileSystems.local().findFileByPath(configuration.path) ?: return null
+    val excludeRoots = ModuleRootManager.getInstance(module).excludeRoots
+    val excludes = excludeRoots
+            .asSequence()
+            .filter { VfsUtil.isAncestor(file, it, false) }
+            .map { VfsUtilCore.getRelativePath(it, rootDir) }
+            .filterNotNull()
+            .map { listOf("-X", it) }
+            .flatten()
+            .toList()
+    val command = listOf(pythonPath, "${MicroPythonFacet.scriptsPath}/microupload.py", "-C", rootPath) +
+            excludes + listOf("-v", devicePath, configuration.path)
+
+    return object : CommandLineState(environment) {
+      override fun startProcess() =
+              OSProcessHandler(GeneralCommandLine(command))
+    }
+  }
+}

--- a/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
@@ -21,6 +21,10 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.OSProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VfsUtilCore
 import com.jetbrains.micropython.run.MicroPythonRunConfiguration
 import com.jetbrains.micropython.settings.MicroPythonFacet
 import com.jetbrains.micropython.settings.MicroPythonTypeHints
@@ -55,19 +59,28 @@ class PyboardDeviceProvider : MicroPythonDeviceProvider {
 
   override fun getRunCommandLineState(configuration: MicroPythonRunConfiguration,
                                       environment: ExecutionEnvironment): CommandLineState? {
-    val facet = configuration.module?.microPythonFacet ?: return null
+    val module = configuration.module ?: return null
+    val facet = module.microPythonFacet ?: return null
     val pythonPath = facet.pythonPath ?: return null
     val devicePath = facet.devicePath ?: return null
     val rootPath = configuration.project.basePath ?: return null
+    val rootDir = StandardFileSystems.local().findFileByPath(rootPath) ?: return null
+    val file = StandardFileSystems.local().findFileByPath(configuration.path) ?: return null
+    val excludeRoots = ModuleRootManager.getInstance(module).excludeRoots
+    val excludes = excludeRoots
+        .asSequence()
+        .filter { VfsUtil.isAncestor(file, it, false) }
+        .map { VfsUtilCore.getRelativePath(it, rootDir) }
+        .filterNotNull()
+        .map { listOf("-X", it) }
+        .flatten()
+        .toList()
+    val command = listOf(pythonPath, "${MicroPythonFacet.scriptsPath}/microupload.py", "-C", rootPath) +
+        excludes + listOf("-v", devicePath, configuration.path)
+
     return object : CommandLineState(environment) {
       override fun startProcess() =
-          OSProcessHandler(GeneralCommandLine(pythonPath,
-                                              "${MicroPythonFacet.scriptsPath}/microupload.py",
-                                              "-C",
-                                              rootPath,
-                                              "-v",
-                                              devicePath,
-                                              configuration.path))
+          OSProcessHandler(GeneralCommandLine(command))
     }
   }
 }

--- a/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/PyboardDeviceProvider.kt
@@ -16,27 +16,13 @@
 
 package com.jetbrains.micropython.devices
 
-import com.intellij.execution.configurations.CommandLineState
-import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.OSProcessHandler
-import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.vfs.StandardFileSystems
-import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.openapi.vfs.VfsUtilCore
-import com.jetbrains.micropython.run.MicroPythonRunConfiguration
-import com.jetbrains.micropython.settings.MicroPythonFacet
 import com.jetbrains.micropython.settings.MicroPythonTypeHints
 import com.jetbrains.micropython.settings.MicroPythonUsbId
-import com.jetbrains.micropython.settings.microPythonFacet
-import com.jetbrains.python.packaging.PyPackageManager
-import com.jetbrains.python.packaging.PyRequirement
 
 /**
  * @author stefanhoelzl
  */
-class PyboardDeviceProvider : MicroPythonDeviceProvider {
+class PyboardDeviceProvider : MicrouploadDeviceProvider() {
   override val persistentName: String
     get() = "Pyboard"
 
@@ -48,39 +34,5 @@ class PyboardDeviceProvider : MicroPythonDeviceProvider {
 
   override val typeHints: MicroPythonTypeHints by lazy {
     MicroPythonTypeHints(listOf("stdlib", "micropython"))
-  }
-
-  override fun getPackageRequirements(sdk: Sdk): List<PyRequirement> {
-    val manager = PyPackageManager.getInstance(sdk)
-    return manager.parseRequirements("""|pyserial>=3.3,<4.0
-                                        |docopt>=0.6.2,<0.7
-                                        |adafruit-ampy>=1.0.5,<1.1""".trimMargin())
-  }
-
-  override fun getRunCommandLineState(configuration: MicroPythonRunConfiguration,
-                                      environment: ExecutionEnvironment): CommandLineState? {
-    val module = configuration.module ?: return null
-    val facet = module.microPythonFacet ?: return null
-    val pythonPath = facet.pythonPath ?: return null
-    val devicePath = facet.devicePath ?: return null
-    val rootPath = configuration.project.basePath ?: return null
-    val rootDir = StandardFileSystems.local().findFileByPath(rootPath) ?: return null
-    val file = StandardFileSystems.local().findFileByPath(configuration.path) ?: return null
-    val excludeRoots = ModuleRootManager.getInstance(module).excludeRoots
-    val excludes = excludeRoots
-        .asSequence()
-        .filter { VfsUtil.isAncestor(file, it, false) }
-        .map { VfsUtilCore.getRelativePath(it, rootDir) }
-        .filterNotNull()
-        .map { listOf("-X", it) }
-        .flatten()
-        .toList()
-    val command = listOf(pythonPath, "${MicroPythonFacet.scriptsPath}/microupload.py", "-C", rootPath) +
-        excludes + listOf("-v", devicePath, configuration.path)
-
-    return object : CommandLineState(environment) {
-      override fun startProcess() =
-          OSProcessHandler(GeneralCommandLine(command))
-    }
   }
 }


### PR DESCRIPTION
Using the pyboard device I noticed that the ignored folders were not respected.
Diving into the code I found that the Esp8266 device provider already deals with this.
So I merged the two devices and extracted the common code into a new base class.