### PR TITLE
Updated Esp8266DeviceProvider.kt usbIds for FDTI programmer autodetect

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/devices/Esp8266DeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/Esp8266DeviceProvider.kt
@@ -24,7 +24,8 @@ class Esp8266DeviceProvider : MicroPythonDeviceProvider {
 
   override val usbIds: List<MicroPythonUsbId>
     get() = listOf(MicroPythonUsbId(0x1A86, 0x7523),
-                   MicroPythonUsbId(0x10C4, 0xEA60))
+                   MicroPythonUsbId(0x10C4, 0xEA60),
+                   MicroPythonUsbId(0x0403, 0x6001))
 
   override val typeHints: MicroPythonTypeHints by lazy {
     MicroPythonTypeHints(listOf("stdlib", "micropython", "esp8266"))


### PR DESCRIPTION
Added FTDI programmer compatibility for autodetect by adding FTDI hardware id to list of USB Ids