### PR TITLE
Only upload file to device if remote is different

### DIFF
--- a/scripts/microupload.py
+++ b/scripts/microupload.py
@@ -22,6 +22,7 @@ Options:
     -X --exclude=PATH       Path to exclude, may be repeated.
     -C --chdir=PATH         Change current directory to path.
     -v --verbose            Verbose output.
+    -d --different          Only Upload if remote file is different to local file.
 """
 
 import time
@@ -31,21 +32,55 @@ from contextlib import suppress
 from typing import List, Iterable, TypeVar, Sequence, Set
 
 from docopt import docopt
-from ampy.pyboard import Pyboard
+from ampy.pyboard import Pyboard, PyboardError
 from ampy.files import Files, DirectoryExistsError
+from hashlib import sha1
+import textwrap
 
 
 __all__ = []
 
-verbose = False
+verbose = True
 T = TypeVar('T')
 
+def get_hash(self, filename):
+    command = """
+        import sys
+        from uhashlib import sha1
+        hash = sha1()
+        with open('{0}', 'rb') as infile:
+                while True:
+                    result = infile.read({1})
+                    hash.update(result)
+                    if result == b'':
+                        break
+                len = sys.stdout.write(hash.digest())
+    """.format(
+        filename, 32
+    )
+    self._pyboard.enter_raw_repl()
+    try:
+        out = self._pyboard.exec_(textwrap.dedent(command))
+    except PyboardError as ex:
+        # Check if this is an OSError #2, i.e. file doesn't exist and
+        # rethrow it as something more descriptive.
+        if ex.args[2].decode("utf-8").find("OSError: [Errno 2] ENOENT") != -1:
+            raise RuntimeError("No such file: {0}".format(filename))
+        else:
+            raise ex
+    self._pyboard.exit_raw_repl()
+    return out
+
+Files.get_hash = get_hash
 
 def main(args: List[str]) -> None:
     global verbose
+    start_time = time.time()
+
     opts = docopt(__doc__, argv=args)
     verbose = opts['--verbose']
     root = opts['PATH']
+    different = opts['--different']
 
     chdir = opts['--chdir']
     if chdir:
@@ -64,7 +99,6 @@ def main(args: List[str]) -> None:
                      for x in list_files(root, opts['--exclude'])]
     else:
         to_upload = [rel_root]
-
     created_cache = set()
     for path in progress('Uploading files', to_upload):
         local_path = os.path.abspath(path)
@@ -76,10 +110,22 @@ def main(args: List[str]) -> None:
         if remote_dir:
             make_dirs(files, remote_dir, created_cache)
         with open(local_path, 'rb') as fd:
-            files.put(remote_path, fd.read())
+            if different:
+                raw = fd.read()
+                local_file_hash = sha1(raw).digest()
+
+                remote_file_hash = files.get_hash(remote_path)
+                if remote_file_hash == local_file_hash:
+                    print("File Identical", file=sys.stderr, flush=True)
+                else:
+                    print("Files different...", file=sys.stderr, flush=True)
+                    files.put(remote_path, raw)
+            else:
+                files.put(remote_path, fd.read())
 
     print('Soft reboot', file=sys.stderr, flush=True)
     soft_reset(board)
+    print("--- %s seconds ---" % (time.time() - start_time), file=sys.stderr, flush=True)
 
 
 def make_dirs(files: Files, path: str,


### PR DESCRIPTION
This PR adds the ability to check if the remote file is different to the local file on upload. If its the same it can skip uploading to save time.
For a single file upload this will increase the time to upload it takes a bit under a second to check if they are different plus the time to upload. However, when working on larger projects with multiple files, if you are only modifying a couple at a time it can speed up the upload process as it will only upload the files that need to be uploaded. It also means you don't need to upload each file individually.

You have to add the `--different` option to the script call otherwise it will use the default to uploading all files.

Just wanted everyone's opinion on whether they see themselves using this or just prefer the old way.

If it was to be implemented I would recommend the run configuration to have a checkbox on whether it is enabled or not. I would also recommend disabling it for single file uploads and save it for project level or other multi-file uploads.