### PR TITLE
Fix device detection in settings panel.

### DIFF
--- a/src/main/kotlin/com/jetbrains/micropython/settings/MicroPythonFacet.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/settings/MicroPythonFacet.kt
@@ -134,20 +134,20 @@ class MicroPythonFacet(facetType: FacetType<out Facet<*>, *>, module: Module, na
 
   fun getOrDetectDevicePathSynchronously(): String? =
       if (autoDetectDevicePath)
-        detectDevicePathSynchronously()
+        detectDevicePathSynchronously(configuration.deviceProvider)
       else
         devicePath
 
-  fun detectDevicePathSynchronously(): String? {
+  fun detectDevicePathSynchronously(deviceProvider: MicroPythonDeviceProvider): String? {
     ApplicationManager.getApplication().assertIsDispatchThread()
 
     var detectedDevicePath: String? = null
-    val deviceProviderName = configuration.deviceProvider.presentableName
+    val deviceProviderName = deviceProvider.presentableName
     val progress = ProgressManager.getInstance()
 
     progress.runProcessWithProgressSynchronously({
       progress.progressIndicator.text = "Detecting connected $deviceProviderName devices..."
-      val detected = findSerialPorts(configuration.deviceProvider, progress.progressIndicator).firstOrNull()
+      val detected = findSerialPorts(deviceProvider, progress.progressIndicator).firstOrNull()
       ApplicationManager.getApplication().invokeLater {
         if (detected == null) {
           Messages.showErrorDialog(module.project,

--- a/src/main/kotlin/com/jetbrains/micropython/settings/MicroPythonSettingsPanel.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/settings/MicroPythonSettingsPanel.kt
@@ -52,7 +52,7 @@ class MicroPythonSettingsPanel(private val module: Module) : JPanel() {
           add(devicePath, BorderLayout.CENTER)
           add(JButton("Detect").apply {
             addActionListener {
-              devicePath.text = module.microPythonFacet?.detectDevicePathSynchronously() ?: ""
+              devicePath.text = module.microPythonFacet?.detectDevicePathSynchronously(selectedProvider) ?: ""
             }
           }, BorderLayout.EAST)
         })


### PR DESCRIPTION
At the moment, the "Detect" button only searches devices using a provider already saved into the configuration. This leads to confusion, as changing the provider in the dropdown will have no effect on the ability to find the currently attached device.

Provided patch fixes that issue by always using a provider from the dropdown on the settings panel. :)