### PR TITLE
fix use posix path on file upload remote_path

### DIFF
--- a/scripts/microupload.py
+++ b/scripts/microupload.py
@@ -68,7 +68,7 @@ def main(args: List[str]) -> None:
     created_cache = set()
     for path in progress('Uploading files', to_upload):
         local_path = os.path.abspath(path)
-        remote_path = os.path.normpath(path)
+        remote_path = os.path.normpath(path).replace(os.path.sep, '/')
         if verbose:
             print('\n{} -> {}'.format(local_path, remote_path),
                   file=sys.stderr, flush=True)


### PR DESCRIPTION
I noticed while uploading files from Windows to my ESP32 device this uploader script would create weird `folder\\filename` file names instead of putting `filename` in `folder`.

This is due to the script using Windows '\\' instead of'/' as path separator for the destination path, which is apparently not properly supported by ampy.files.Files.

Anyway this fixes the issue for ESP32 and any other devices affected. It should not have any impact on non affected boards, even though I have only tested it on my ESP32.