### PR TITLE
Support for raspberry pi pico

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The plugin supports Python development for these devices:
 * [ESP8266](https://github.com/vlasovskikh/intellij-micropython/wiki/ESP8266)
 * [PyBoard](https://github.com/vlasovskikh/intellij-micropython/wiki/Pyboard)
 * [BBC Micro:bit](https://github.com/vlasovskikh/intellij-micropython/wiki/BBC-Micro%3Abit)
+* [Raspberry Pi Pico](https://www.raspberrypi.org/products/raspberry-pi-pico/)
 
 It will support more MicroPython devices and more device-specific and MicroPython-specific modules eventually. We are
 interested in your contributions to the project. Feel free to open issues and send pull requests!

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=SNAPSHOT
 kotlinVersion=1.3.21
 #ideaVersion=IC-202-EAP-SNAPSHOT
-ideaVersion=PC-202-EAP-SNAPSHOT
+ideaVersion=PC-LATEST-EAP-SNAPSHOT
 pythonPlugin=PythonCore:202.7319.64
 downloadIdeaSources=true
 publishUsername=username

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=SNAPSHOT
 kotlinVersion=1.3.21
 #ideaVersion=IC-202-EAP-SNAPSHOT
-ideaVersion=PC-LATEST-EAP-SNAPSHOT
+ideaVersion=PC-202-EAP-SNAPSHOT
 pythonPlugin=PythonCore:202.7319.64
 downloadIdeaSources=true
 publishUsername=username

--- a/src/main/kotlin/com/jetbrains/micropython/devices/RPiPicoDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/RPiPicoDeviceProvider.kt
@@ -1,0 +1,48 @@
+package com.jetbrains.micropython.devices
+
+import com.intellij.execution.configurations.CommandLineState
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.OSProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.projectRoots.Sdk
+import com.jetbrains.micropython.run.MicroPythonRunConfiguration
+import com.jetbrains.micropython.run.getMicroUploadCommand
+import com.jetbrains.micropython.settings.MicroPythonTypeHints
+import com.jetbrains.micropython.settings.MicroPythonUsbId
+import com.jetbrains.python.packaging.PyPackageManager
+import com.jetbrains.python.packaging.PyRequirement
+
+/**
+ * @author timsavage
+ */
+class RPiPicoDeviceProvider : MicroPythonDeviceProvider {
+  override val persistentName: String
+    get() = "Raspberry Pi Pico"
+
+  override val documentationURL: String
+    get() = "https://www.raspberrypi.org/documentation/pico/getting-started/"
+
+  override val usbIds: List<MicroPythonUsbId>
+    get() = listOf(MicroPythonUsbId(0x2E8A, 0x05))
+
+  override val typeHints: MicroPythonTypeHints by lazy {
+    MicroPythonTypeHints(listOf("stdlib", "micropython", "rpi_pico"))
+  }
+
+  override fun getPackageRequirements(sdk: Sdk): List<PyRequirement> {
+    val manager = PyPackageManager.getInstance(sdk)
+    return manager.parseRequirements("""|pyserial>=3.3,<4.0
+                                        |docopt>=0.6.2,<0.7""".trimMargin())
+  }
+
+  override fun getRunCommandLineState(configuration: MicroPythonRunConfiguration,
+                                      environment: ExecutionEnvironment): CommandLineState? {
+    val module = configuration.module ?: return null
+    val command = getMicroUploadCommand(configuration.path, module) ?: return null
+
+    return object : CommandLineState(environment) {
+      override fun startProcess() =
+          OSProcessHandler(GeneralCommandLine(command))
+    }
+  }
+}

--- a/src/main/kotlin/com/jetbrains/micropython/devices/RPiPicoDeviceProvider.kt
+++ b/src/main/kotlin/com/jetbrains/micropython/devices/RPiPicoDeviceProvider.kt
@@ -32,7 +32,8 @@ class RPiPicoDeviceProvider : MicroPythonDeviceProvider {
   override fun getPackageRequirements(sdk: Sdk): List<PyRequirement> {
     val manager = PyPackageManager.getInstance(sdk)
     return manager.parseRequirements("""|pyserial>=3.3,<4.0
-                                        |docopt>=0.6.2,<0.7""".trimMargin())
+                                        |docopt>=0.6.2,<0.7
+                                        |adafruit-ampy>=1.0.5,<1.1""".trimMargin())
   }
 
   override fun getRunCommandLineState(configuration: MicroPythonRunConfiguration,

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,8 +50,8 @@
         <li>Run REPL on a device</li>
       </ul>
       <br/>
-      <p>Currently the plugin supports ESP8266, Pyboard, and Micro:bit devices. Your feedback and contributions are
-        welcome! See <a href="https://github.com/vlasovskikh/intellij-micropython">the project page</a> on GitHub.</p>
+      <p>Currently the plugin supports ESP8266, Pyboard, Micro:bit and RPi Pico devices. Your feedback and contributions
+        are welcome! See <a href="https://github.com/vlasovskikh/intellij-micropython">the project page</a> on GitHub.</p>
     ]]></description>
   <version>SNAPSHOT</version>
   <vendor>JetBrains</vendor>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -87,6 +87,7 @@
     <deviceProvider implementation="com.jetbrains.micropython.devices.MicroBitDeviceProvider"/>
     <deviceProvider implementation="com.jetbrains.micropython.devices.Esp8266DeviceProvider"/>
     <deviceProvider implementation="com.jetbrains.micropython.devices.PyboardDeviceProvider"/>
+    <deviceProvider implementation="com.jetbrains.micropython.devices.RPiPicoDeviceProvider"/>
   </extensions>
 
   <actions>

--- a/typehints/rpi_pico/rp2.pyi
+++ b/typehints/rpi_pico/rp2.pyi
@@ -1,3 +1,10 @@
+"""
+Raspberry Pi Pico specific micropython support.
+
+These methods are not fully documented and this is a best effort to produce the interface
+
+"""
+
 from typing import List
 
 

--- a/typehints/rpi_pico/rp2.pyi
+++ b/typehints/rpi_pico/rp2.pyi
@@ -1,0 +1,87 @@
+from typing import List
+
+
+class Flash:
+    """
+    Low level access to flash device
+    """
+
+    def ioctl(self):
+        pass
+
+    def readblocks(self):
+        pass
+
+    def writeblocks(self):
+        pass
+
+
+class irq:
+    """
+    IRQ definition
+    """
+
+    def flags(self) -> int:
+        """
+        IRQ flags
+        """
+
+    def trigger(self):
+        """
+        Trigger IRQ
+        """
+
+
+class PIO:
+    IN_LOW: int = 0
+    IN_HIGH: int = 1
+    OUT_LOW: int = 2
+    OUT_HIGH: int = 3
+    SHIFT_LEFT: int = 0
+    SHIFT_RIGHT: int = 1
+    IRQ_SM0: int = 256
+    IRQ_SM1: int = 512
+    IRQ_SM2: int = 1024
+    IRQ_SM3: int = 2048
+
+    def __init__(self, num: int):
+        pass
+
+    def irq(self, callback: Optional[Callable[["PIO"], None]]) -> irq:
+        pass
+
+
+class StateMachine:
+    """
+    Instantiate a state machine with a program.
+    """
+    def __init__(self, num: int, prog: List[Any], freq: int = None, set_base: "Pin" = None) -> None:
+        pass
+
+    def active(self) -> bool:
+        """
+        This state machine is active
+        """
+
+    def init(self, prog: List[Any]):
+        """
+        Initialise and start a PIO program
+        """
+
+    def irq(self) -> PIO.irq:
+        pass
+
+    def put(self, data: bytes):
+        """
+        Send data to PIO program
+        """
+
+
+class PIOASMError(Exception):
+    pass
+
+
+def asm_pio(**kwargs) -> List[Any]:
+    """
+    Assemble a PIO program
+    """


### PR DESCRIPTION
Adds support for the Raspberry Pi Pico board.

- Is autodetected via its USB identifiers
- REPL works
- Uploading files works

Type hints are "best effort" at this point, I have reverse engineered what I could from the available documentation and poking about in the REPL. These API's are also under development, even the official docs are not always correct.

Covers #132 