### PR TITLE
Fixed Upload Path bug

### DIFF
--- a/scripts/microupload.py
+++ b/scripts/microupload.py
@@ -76,7 +76,7 @@ def main(args: List[str]) -> None:
         if remote_dir:
             make_dirs(files, remote_dir, created_cache)
         with open(local_path, 'rb') as fd:
-            files.put(remote_path, fd.read())
+            files.put(remote_path.replace(os.path.sep, '/'), fd.read())
 
     print('Soft reboot', file=sys.stderr, flush=True)
     soft_reset(board)


### PR DESCRIPTION
Starting from a blank file system, files can upload with the filename '//path//to/file.py' in the root directory instead of being uploaded into the directory 'path/to/'. This PR changes the remote_path to a posix path like make_dirs does to ensure the file is uploaded properly regardless of the OS used.

EDIT: This Fixes #128