### PR TITLE
Add auto-close REPL workaround, indent changes

### DIFF
--- a/scripts/microupload.py
+++ b/scripts/microupload.py
@@ -52,14 +52,14 @@ def main(args: List[str]) -> None:
     if chdir:
         os.chdir(chdir)
 
-    check_for_repl()        
-        
+    check_for_repl()
+
     port = opts['PORT']
     print('Connecting to {}'.format(port), file=sys.stderr)
     board = Pyboard(port)
     files = Files(board)
     rel_root = os.path.relpath(root, os.getcwd())
-    
+
     wait_for_board()
 
     if os.path.isdir(root):
@@ -149,17 +149,16 @@ def check_for_repl():
         for p in targets:
             p.terminate()
         _, alive = psutil.wait_procs(targets, timeout=300)
-    
-    if len(alive) >= 1:
-        print("Well, it looks like the MicroPython REPL is still running, trying to kill it now...", file=sys.stderr)
-        for p in targets:
-            p.kill()
-        _, notdead = psutil.wait_procs(targets, timeout=300)
-        
-    if len(notdead) >= 1:
-        print("Unable to close the MicroPython REPL automatically...", file=sys.stderr)
-        print("Please close it manually and try again", file=sys.stderr)
-        sys.exit()
+        if len(alive) >= 1:
+            print("Well, it looks like the MicroPython REPL is still running, trying to kill it now...", file=sys.stderr)
+            for p in targets:
+                p.kill()
+            _, notdead = psutil.wait_procs(targets, timeout=300)
+        if len(notdead) >= 1:
+            print("Unable to close the MicroPython REPL automatically...", file=sys.stderr)
+            print("Please close it manually and try again", file=sys.stderr)
+            sys.exit()
+
 
 if __name__ == '__main__':
     main(sys.argv[1:])


### PR DESCRIPTION
Note: adds requirement: psutils

This is intended to be a quality of life improvement while we hope for https://github.com/vlasovskikh/intellij-micropython/pull/139 to come to fruition; to be honest, since it has been a year and 3 months since there has been any updates to the WIP: enhancement issue I don't have a lot of faith this will be completed anytime soon.

Because of that I figured out how to check the system's running processes for the MicroPython REPL and close/kill it so the flash process (or script) will continue successfully.

I tried all day to implement restarting the REPL when the flash was complete, but I can't figure out a way to launch the MicroPython REPL the way it was originally (as a terminal window in PyCharm).

I am a hobby/junior programmer so feedback is appreciated!